### PR TITLE
feat: rename `exhaustive.tag`, add tagged overload and expose `exhaustive` types

### DIFF
--- a/.changeset/orange-pens-jog.md
+++ b/.changeset/orange-pens-jog.md
@@ -1,0 +1,26 @@
+---
+"exhaustive": minor
+---
+
+## Add `exhaustive.tag` overload to core function
+
+The same functionality of `exhaustive.tag` is available in the main function by adding a third argument to `exhaustive` that will trigger the Tagged Union overload.
+
+```ts
+const area = (s: Shape) => {
+  return exhaustive(s, 'kind', {
+    square: (shape) => shape.size ** 2,
+    rectangle: (shape) => shape.width * shape.height,
+    circle: (shape) => Math.PI * shape.radius ** 2,
+  });
+};
+```
+
+PS: Note that TypeScript has a limitation inferring the Tagged Union overload via argument types because they are generic values. Typescript will only fallback to the Tagged Union overload when you add a third argument. This means autocomplete for the Tagged Union keys will not exist until you declare an empty object as the third argument:
+
+```ts
+exhaustive(shape, 'kind', {});
+//                        ^ this will trigger the Tagged Union overload
+```
+
+This feature is being added as a reflect of how the API was originally intended. Use it at your own convenience, but if you prefer the better DX of inferred types from the start, calling `exhaustive.tag` is still preferrable.

--- a/.changeset/quick-ants-bathe.md
+++ b/.changeset/quick-ants-bathe.md
@@ -1,0 +1,34 @@
+---
+"exhaustive": major
+---
+
+## Exposed `Exhaustive` types and added new generic slot in core function for type of output
+
+The types `ExhaustiveUnion` and `Exhaustiveag` are now exposed for your own convenience if you'd like to override the generic slots of `exhaustive`. The inferred output was also added as a new slot in the function generics, allowing you to also override the output value of `exhaustive`:
+
+```tsx
+import { exhaustive, type ExhaustiveTag } from 'exhaustive';
+
+exhaustive<RequestState, 'state', ExhaustiveTag<RequestState, 'state'>, JSX.Element>(request, 'state', {
+  IDLE: () => null,
+  LOADING: (value) => <Loading />,
+  SUCCESS: (value) => <List data={value.data} />,
+  ERROR: (value) => <Error message={value.error} />,
+});
+```
+
+### BREAKING CHANGES
+
+#### Renamed `_tag` method to `tag`
+The `_tag` method was exposed as a some sort of secondary method to enhance the experience with Tagged Unions. Since the DX of using it is vastly superior compared to the Tagged Union overload in `exhaustive`, and it seems that we cannot improve the overload inference on the core funcion, the underscore has been removed from the method name and now you should used it as `exhaustive.tag` to make it official as the preferred way to exhaustive check Tagged Unions:
+
+```diff
+const area = (s: Shape) => {
+- return exhaustive._tag(s, 'kind', {
++ return exhaustive.tag(s, 'kind', {
+    square: (shape) => shape.size ** 2,
+    rectangle: (shape) => shape.width * shape.height,
+    circle: (shape) => Math.PI * shape.radius ** 2,
+  });
+};
+```

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ const getUserPermissions = (role: Role) =>
 ## 📝 Features
 
 ### Tagged Unions
-When working with `Tagged Unions` (or `Discriminated Unions`), use `exhaustive._tag` to inform what property to discriminate between union members:
+When working with `Tagged Unions` (or `Discriminated Unions`), use `exhaustive.tag` to inform what property to discriminate between union members:
 
 ```ts
 interface Square {
@@ -81,13 +81,32 @@ interface Circle {
 type Shape = Square | Rectangle | Circle;
 
 const area = (s: Shape) => {
-  return exhaustive._tag(s, 'kind', {
+  return exhaustive.tag(s, 'kind', {
     square: (shape) => shape.size ** 2,
     rectangle: (shape) => shape.width * shape.height,
     circle: (shape) => Math.PI * shape.radius ** 2,
   });
 };
 ```
+
+An overload is also available in the core `exhaustive` function: by adding a third parameter to the function, Typescript will fallback to the Tagged Union overload.
+
+```ts
+exhaustive(s, 'kind', {
+  square: (shape) => shape.size ** 2,
+  rectangle: (shape) => shape.width * shape.height,
+  circle: (shape) => Math.PI * shape.radius ** 2,
+});
+```
+
+PS: Note that TypeScript has a limitation inferring the Tagged Union overload via argument types because they are generic values. This means autocomplete for the Tagged Union keys will not exist until you declare an empty object as the third argument:
+
+```ts
+exhaustive(s, 'kind', {});
+//                     ^ this will trigger the Tagged Union overload
+```
+
+This overload exists so you can use it at your own convenience, but if you prefer the better DX of inferred types from the start, calling `exhaustive.tag` is still preferrable.
 
 ### Type Narrowing
 For every case checked, `exhaustive` will narrow the type of input:
@@ -104,7 +123,7 @@ const getRoleLabel = (r: Role) =>
   });
 
 const area = (s: Shape) => {
-  return exhaustive._tag(s, 'kind', {
+  return exhaustive.tag(s, 'kind', {
     square: (shape) => shape.size ** 2,
 //             ^? shape is Square
     rectangle: (shape) => shape.width * shape.height,

--- a/src/exhaustive.spec.ts
+++ b/src/exhaustive.spec.ts
@@ -1,78 +1,132 @@
 import { exhaustive } from './exhaustive';
 
 describe('exhaustive', () => {
-  describe('when used with a union of strings', () => {
-    type Union = 'IDLE' | 'LOADING' | 'SUCCESS' | 'ERROR';
+  describe('when used with two arguments', () => {
+    describe('when used with a union of strings', () => {
+      type Union = 'IDLE' | 'LOADING' | 'SUCCESS' | 'ERROR';
 
-    type ExecOptions = { withFallback: boolean };
+      type ExecOptions = { withFallback: boolean };
 
-    const exec = (union: Union, options?: ExecOptions) =>
-      exhaustive(union, {
-        IDLE: (value) => value.toLowerCase(),
-        LOADING: (value) => value.toLowerCase(),
-        SUCCESS: (value) => value.toLowerCase(),
-        ERROR: (value) => value.toLowerCase(),
-        ...(options?.withFallback ? { _: () => '🚨' } : {}),
+      const exec = (union: Union, options?: ExecOptions) =>
+        exhaustive(union, {
+          IDLE: (value) => value.toLowerCase(),
+          LOADING: (value) => value.toLowerCase(),
+          SUCCESS: (value) => value.toLowerCase(),
+          ERROR: (value) => value.toLowerCase(),
+          ...(options?.withFallback ? { _: () => '🚨' } : {}),
+        });
+
+      const eachCase = it.each([
+        'IDLE',
+        'LOADING',
+        'SUCCESS',
+        'ERROR',
+      ] as const);
+
+      eachCase('returns the lower cased value for "%s"', (value) => {
+        expect(exec(value)).toBe(value.toLowerCase());
       });
 
-    const eachCase = it.each(['IDLE', 'LOADING', 'SUCCESS', 'ERROR'] as const);
+      describe('when no fallback is declared', () => {
+        it('throws an exception when an invalid value is passed through', () => {
+          expect(() => exec('unknown' as any)).toThrow(TypeError);
+        });
+      });
 
-    eachCase('returns the lower cased value for "%s"', (value) => {
-      expect(exec(value)).toBe(value.toLowerCase());
-    });
-
-    describe('when no fallback is declared', () => {
-      it('throws an exception when an invalid value is passed through', () => {
-        expect(() => exec('unknown' as any)).toThrow(TypeError);
+      describe('when a fallback is declared', () => {
+        it('returns the declared fallback value', () => {
+          expect(exec('unknown' as any, { withFallback: true })).toBe('🚨');
+        });
       });
     });
 
-    describe('when a fallback is declared', () => {
-      it('returns the declared fallback value', () => {
-        expect(exec('unknown' as any, { withFallback: true })).toBe('🚨');
+    describe('when used with an enum', () => {
+      enum Union {
+        'IDLE' = 'IDLE',
+        'LOADING' = 'LOADING',
+        'SUCCESS' = 'SUCCESS',
+        'ERROR' = 'ERROR',
+      }
+
+      type ExecOptions = { withFallback: boolean };
+
+      const exec = (union: Union, options?: ExecOptions) =>
+        exhaustive(union, {
+          IDLE: (value) => value.toLowerCase(),
+          LOADING: (value) => value.toLowerCase(),
+          SUCCESS: (value) => value.toLowerCase(),
+          ERROR: (value) => value.toLowerCase(),
+          ...(options?.withFallback ? { _: () => '🚨' } : {}),
+        });
+
+      const eachCase = it.each([
+        Union.IDLE,
+        Union.LOADING,
+        Union.SUCCESS,
+        Union.ERROR,
+      ] as const);
+
+      eachCase('returns the lower cased value for "%s"', (value) => {
+        expect(exec(value)).toBe(value.toLowerCase());
+      });
+
+      describe('when no fallback is declared', () => {
+        it('throws an exception when an invalid value is passed through', () => {
+          expect(() => exec('unknown' as any)).toThrow(TypeError);
+        });
+      });
+
+      describe('when a fallback is declared', () => {
+        it('returns the declared fallback value', () => {
+          expect(exec('unknown' as any, { withFallback: true })).toBe('🚨');
+        });
       });
     });
   });
 
-  describe('when used with an enum', () => {
-    enum Union {
-      'IDLE' = 'IDLE',
-      'LOADING' = 'LOADING',
-      'SUCCESS' = 'SUCCESS',
-      'ERROR' = 'ERROR',
-    }
+  describe('when used with three arguments', () => {
+    describe('when used with a discriminated union', () => {
+      type TaggedUnion =
+        | { state: 'IDLE' }
+        | { state: 'LOADING' }
+        | { state: 'SUCCESS'; data: string }
+        | { state: 'ERROR'; error: string };
 
-    type ExecOptions = { withFallback: boolean };
+      type ExecOptions = { withFallback: boolean };
 
-    const exec = (union: Union, options?: ExecOptions) =>
-      exhaustive(union, {
-        IDLE: (value) => value.toLowerCase(),
-        LOADING: (value) => value.toLowerCase(),
-        SUCCESS: (value) => value.toLowerCase(),
-        ERROR: (value) => value.toLowerCase(),
-        ...(options?.withFallback ? { _: () => '🚨' } : {}),
+      const exec = (union: TaggedUnion, options?: ExecOptions) =>
+        exhaustive(union, 'state', {
+          IDLE: (value) => value.state.toLowerCase(),
+          LOADING: (value) => value.state.toLowerCase(),
+          SUCCESS: (value) => value.state.toLowerCase(),
+          ERROR: (value) => value.state.toLowerCase(),
+          ...(options?.withFallback ? { _: () => '🚨' } : {}),
+        });
+
+      const eachCase = it.each([
+        { state: 'IDLE' },
+        { state: 'LOADING' },
+        { state: 'SUCCESS', data: '✅' },
+        { state: 'ERROR', error: '❌' },
+      ] as TaggedUnion[]);
+
+      eachCase(
+        'returns the lower cased value of the discriminator for "%s"',
+        (value) => {
+          expect(exec(value)).toBe(value.state.toLowerCase());
+        },
+      );
+
+      describe('when no fallback is declared', () => {
+        it('throws an exception when an invalid value is passed through', () => {
+          expect(() => exec('unknown' as any)).toThrow(TypeError);
+        });
       });
 
-    const eachCase = it.each([
-      Union.IDLE,
-      Union.LOADING,
-      Union.SUCCESS,
-      Union.ERROR,
-    ] as const);
-
-    eachCase('returns the lower cased value for "%s"', (value) => {
-      expect(exec(value)).toBe(value.toLowerCase());
-    });
-
-    describe('when no fallback is declared', () => {
-      it('throws an exception when an invalid value is passed through', () => {
-        expect(() => exec('unknown' as any)).toThrow(TypeError);
-      });
-    });
-
-    describe('when a fallback is declared', () => {
-      it('returns the declared fallback value', () => {
-        expect(exec('unknown' as any, { withFallback: true })).toBe('🚨');
+      describe('when a fallback is declared', () => {
+        it('returns the declared fallback value', () => {
+          expect(exec('unknown' as any, { withFallback: true })).toBe('🚨');
+        });
       });
     });
   });

--- a/src/exhaustive.spec.ts
+++ b/src/exhaustive.spec.ts
@@ -143,7 +143,7 @@ describe('exhaustive._tag', () => {
     type ExecOptions = { withFallback: boolean };
 
     const exec = (union: TaggedUnion, options?: ExecOptions) =>
-      exhaustive._tag(union, 'state', {
+      exhaustive.tag(union, 'state', {
         IDLE: (value) => value.state.toLowerCase(),
         LOADING: (value) => value.state.toLowerCase(),
         SUCCESS: (value) => value.state.toLowerCase(),

--- a/src/exhaustive.ts
+++ b/src/exhaustive.ts
@@ -2,6 +2,16 @@ import { corrupt } from './corrupt';
 
 type AnyFunction = (...args: any[]) => unknown;
 
+type ExhaustiveUnion<Union extends string> = {
+  [Key in Union]: (value: Key) => any;
+} & ExhaustiveFallback;
+
+type ExhaustiveTag<Union extends object, Tag extends keyof Union> = {
+  [Key in Union[Tag] & string]: (
+    value: Extract<Union, { [K in Tag]: Key }>,
+  ) => any;
+} & ExhaustiveFallback;
+
 type ExhaustiveFallback = {
   /**
    * Default fallback
@@ -22,53 +32,54 @@ type ValidateKeys<T, U> = [keyof T] extends [keyof U]
       [Key in keyof U]: Key extends keyof T ? T[Key] : never;
     };
 
-interface Exhaustive {
-  <
-    Union extends string,
-    Match extends ExhaustiveUnion<Union> = ExhaustiveUnion<Union>,
-  >(
-    union: Union,
-    match: ValidateKeys<Match, ExhaustiveUnion<Union>>,
-  ): Match[keyof Match] extends AnyFunction
-    ? ReturnType<Match[keyof Match]>
-    : never;
-  _tag: <
-    Union extends object,
-    Tag extends keyof Union,
-    Match extends ExhaustiveTag<Union, Tag> = ExhaustiveTag<Union, Tag>,
-  >(
-    union: Union,
-    tag: Tag,
-    match: ValidateKeys<Match, ExhaustiveTag<Union, Tag>>,
-  ) => Match[keyof Match] extends AnyFunction
-    ? ReturnType<Match[keyof Match]>
-    : never;
-}
+function exhaustive<
+  Union extends string,
+  Match extends ExhaustiveUnion<Union> = ExhaustiveUnion<Union>,
+>(
+  union: Union,
+  match: ValidateKeys<Match, ExhaustiveUnion<Union>>,
+): Match[keyof Match] extends AnyFunction
+  ? ReturnType<Match[keyof Match]>
+  : never;
+function exhaustive<
+  Union extends object,
+  Tag extends keyof Union,
+  Match extends ExhaustiveTag<Union, Tag> = ExhaustiveTag<Union, Tag>,
+>(
+  union: Union,
+  tag: Tag,
+  match: ValidateKeys<Match, ExhaustiveTag<Union, Tag>>,
+): Match[keyof Match] extends AnyFunction
+  ? ReturnType<Match[keyof Match]>
+  : never;
+function exhaustive(union: any, matchOrKeyofUnion: any, match?: any) {
+  if (typeof match !== 'undefined') {
+    return exhaustive._tag(union, matchOrKeyofUnion, match);
+  }
 
-type ExhaustiveUnion<Union extends string> = {
-  [Key in Union]: (value: Key) => any;
-} & ExhaustiveFallback;
-
-type ExhaustiveTag<Union extends object, Tag extends keyof Union> = {
-  [Key in Union[Tag] & string]: (
-    value: Extract<Union, { [K in Tag]: Key }>,
-  ) => any;
-} & ExhaustiveFallback;
-
-export const exhaustive: Exhaustive = (union, match) => {
-  if (!Object.prototype.hasOwnProperty.call(match, union)) {
-    if (Object.prototype.hasOwnProperty.call(match, '_')) {
-      return (match as Required<ExhaustiveFallback>)._();
+  if (!Object.prototype.hasOwnProperty.call(matchOrKeyofUnion, union)) {
+    if (Object.prototype.hasOwnProperty.call(matchOrKeyofUnion, '_')) {
+      return (matchOrKeyofUnion as Required<ExhaustiveFallback>)._();
     }
 
     return corrupt(union as never);
   }
 
-  const result = match[union as string];
+  const result = (matchOrKeyofUnion as object)[union as string];
   return result(union);
-};
+}
 
-exhaustive._tag = (union, tag, match) => {
+exhaustive._tag = <
+  Union extends object,
+  Tag extends keyof Union,
+  Match extends ExhaustiveTag<Union, Tag> = ExhaustiveTag<Union, Tag>,
+>(
+  union: Union,
+  tag: Tag,
+  match: ValidateKeys<Match, ExhaustiveTag<Union, Tag>>,
+): Match[keyof Match] extends AnyFunction
+  ? ReturnType<Match[keyof Match]>
+  : never => {
   const key = union[tag];
 
   if (!Object.prototype.hasOwnProperty.call(match, key)) {
@@ -82,3 +93,5 @@ exhaustive._tag = (union, tag, match) => {
   const result = match[key as string];
   return result(union);
 };
+
+export { exhaustive };

--- a/src/exhaustive.ts
+++ b/src/exhaustive.ts
@@ -54,7 +54,7 @@ function exhaustive<
   : never;
 function exhaustive(union: any, matchOrKeyofUnion: any, match?: any) {
   if (typeof match !== 'undefined') {
-    return exhaustive._tag(union, matchOrKeyofUnion, match);
+    return exhaustive.tag(union, matchOrKeyofUnion, match);
   }
 
   if (!Object.prototype.hasOwnProperty.call(matchOrKeyofUnion, union)) {
@@ -69,7 +69,7 @@ function exhaustive(union: any, matchOrKeyofUnion: any, match?: any) {
   return result(union);
 }
 
-exhaustive._tag = <
+exhaustive.tag = <
   Union extends object,
   Tag extends keyof Union,
   Match extends ExhaustiveTag<Union, Tag> = ExhaustiveTag<Union, Tag>,

--- a/src/exhaustive.ts
+++ b/src/exhaustive.ts
@@ -2,11 +2,11 @@ import { corrupt } from './corrupt';
 
 type AnyFunction = (...args: any[]) => unknown;
 
-type ExhaustiveUnion<Union extends string> = {
+export type ExhaustiveUnion<Union extends string> = {
   [Key in Union]: (value: Key) => any;
 } & ExhaustiveFallback;
 
-type ExhaustiveTag<Union extends object, Tag extends keyof Union> = {
+export type ExhaustiveTag<Union extends object, Tag extends keyof Union> = {
   [Key in Union[Tag] & string]: (
     value: Extract<Union, { [K in Tag]: Key }>,
   ) => any;
@@ -35,23 +35,22 @@ type ValidateKeys<T, U> = [keyof T] extends [keyof U]
 function exhaustive<
   Union extends string,
   Match extends ExhaustiveUnion<Union> = ExhaustiveUnion<Union>,
->(
-  union: Union,
-  match: ValidateKeys<Match, ExhaustiveUnion<Union>>,
-): Match[keyof Match] extends AnyFunction
-  ? ReturnType<Match[keyof Match]>
-  : never;
+  Output = Match[keyof Match] extends AnyFunction
+    ? ReturnType<Match[keyof Match]>
+    : never,
+>(union: Union, match: ValidateKeys<Match, ExhaustiveUnion<Union>>): Output;
 function exhaustive<
   Union extends object,
   Tag extends keyof Union,
   Match extends ExhaustiveTag<Union, Tag> = ExhaustiveTag<Union, Tag>,
+  Output = Match[keyof Match] extends AnyFunction
+    ? ReturnType<Match[keyof Match]>
+    : never,
 >(
   union: Union,
   tag: Tag,
   match: ValidateKeys<Match, ExhaustiveTag<Union, Tag>>,
-): Match[keyof Match] extends AnyFunction
-  ? ReturnType<Match[keyof Match]>
-  : never;
+): Output;
 function exhaustive(union: any, matchOrKeyofUnion: any, match?: any) {
   if (typeof match !== 'undefined') {
     return exhaustive.tag(union, matchOrKeyofUnion, match);
@@ -73,13 +72,14 @@ exhaustive.tag = <
   Union extends object,
   Tag extends keyof Union,
   Match extends ExhaustiveTag<Union, Tag> = ExhaustiveTag<Union, Tag>,
+  Output = Match[keyof Match] extends AnyFunction
+    ? ReturnType<Match[keyof Match]>
+    : never,
 >(
   union: Union,
   tag: Tag,
   match: ValidateKeys<Match, ExhaustiveTag<Union, Tag>>,
-): Match[keyof Match] extends AnyFunction
-  ? ReturnType<Match[keyof Match]>
-  : never => {
+): Output => {
   const key = union[tag];
 
   if (!Object.prototype.hasOwnProperty.call(match, key)) {

--- a/src/exhaustive.ts
+++ b/src/exhaustive.ts
@@ -51,20 +51,30 @@ function exhaustive<
   tag: Tag,
   match: ValidateKeys<Match, ExhaustiveTag<Union, Tag>>,
 ): Output;
-function exhaustive(union: any, matchOrKeyofUnion: any, match?: any) {
+function exhaustive(
+  unionOrObject: string | object,
+  matchOrKeyofUnion: string | object,
+  match?: object,
+) {
   if (typeof match !== 'undefined') {
-    return exhaustive.tag(union, matchOrKeyofUnion, match);
+    const unionObject = unionOrObject as object;
+    const keyofUnion = matchOrKeyofUnion as keyof typeof unionObject;
+
+    return exhaustive.tag(unionObject, keyofUnion, match);
   }
 
-  if (!Object.prototype.hasOwnProperty.call(matchOrKeyofUnion, union)) {
-    if (Object.prototype.hasOwnProperty.call(matchOrKeyofUnion, '_')) {
-      return (matchOrKeyofUnion as Required<ExhaustiveFallback>)._();
+  const union = unionOrObject as string;
+  const unionMatch = matchOrKeyofUnion as object;
+
+  if (!Object.prototype.hasOwnProperty.call(unionMatch, union)) {
+    if (Object.prototype.hasOwnProperty.call(unionMatch, '_')) {
+      return (unionMatch as Required<ExhaustiveFallback>)._();
     }
 
     return corrupt(union as never);
   }
 
-  const result = (matchOrKeyofUnion as object)[union as string];
+  const result = unionMatch[union];
   return result(union);
 }
 


### PR DESCRIPTION
This PR removes the underscore from `_tag`, adds an overload to core function to work with Tagged Unions and expose `Exhaustive` types 